### PR TITLE
add error catch to avoid execution stopping bc of a few broken links

### DIFF
--- a/PastTwitter.R
+++ b/PastTwitter.R
@@ -309,7 +309,7 @@ extractAccountInfo <- function(snapshot_df = data.frame(0), t_out = 120) {
       rm(list = c('followers','following', 'favorites', 'tweets'))
     },
     error = function(e) {
-      print(paste0(turl, "row:", i, "yielded the following error: ", e, '. Skipping...'))
+      print(paste0(turl, " row: ", i, " yielded the following error: ", e, '. Skipping...'))
     }
     )    
   }

--- a/PastTwitter.R
+++ b/PastTwitter.R
@@ -97,7 +97,6 @@ extractAccountInfo <- function(snapshot_df = data.frame(0), t_out = 120) {
       # Read HTML of snapshot page
       # archive.org takes some time
       # wrapped in httr:GET to increase timeout tolerance
-      page <- read_html(df$surl[i])
       page <- df$surl[i] %>% GET(., timeout(t_out)) %>% read_html()
       
       # Select Profile Navigation node


### PR DESCRIPTION
suggesting a tiny change with `tryCatch` to make sure execution does not stop when pulling data from one or few of the URLs fails.

have been using the functions to pull follower # info from an account with lots of snapshots, and this happened hours into execution, forcing me to restart the process from scratch.

also reintroducing timeout arguments as default, as this was also a major issue with a slightly unstable connection.
